### PR TITLE
Optimized

### DIFF
--- a/stt.py
+++ b/stt.py
@@ -1,30 +1,24 @@
 import vosk
 import sys
 import sounddevice as sd
-import queue
 import json
 
 model = vosk.Model("model_small")
 samplerate = 16000
 device = 2
-
-q = queue.Queue()
-
-
-def q_callback(indata, frames, time, status):
-    if status:
-        print(status, file=sys.stderr)
-    q.put(bytes(indata))
-
+blocksize = 16000
 
 def va_listen(callback):
-    with sd.RawInputStream(samplerate=samplerate, blocksize=8000, device=device, dtype='int16',
-                           channels=1, callback=q_callback):
+    def callback_wrapper(indata, frames, time, status):
+        if status:
+            print(status, file=sys.stderr)
+        result = rec.AcceptWaveform(indata)
+        if result:
+            text = json.loads(rec.Result())["text"]
+            callback(text)
 
+    with sd.RawInputStream(samplerate=samplerate, blocksize=blocksize, device=device, dtype='int16',
+                           channels=1, callback=callback_wrapper):
         rec = vosk.KaldiRecognizer(model, samplerate)
         while True:
-            data = q.get()
-            if rec.AcceptWaveform(data):
-                callback(json.loads(rec.Result())["text"])
-            #else:
-            #    print(rec.PartialResult())
+            pass


### PR DESCRIPTION
Instead of using a queue to store the audio data, you can directly pass the data to the KaldiRecognizer in the callback function. This can reduce the overhead of managing the queue.

You can increase the blocksize of the RawInputStream to reduce the number of callback invocations, which can improve performance.

In this code, the audio data is passed directly to the KaldiRecognizer in the callback_wrapper function. The blocksize of the RawInputStream is increased to match the size of the audio data that is passed to the recognizer in each callback. Finally, an infinite loop is added to keep the program running