### PR TITLE
Fixes to start Jarvis

### DIFF
--- a/crates/jarvis-app/build.rs
+++ b/crates/jarvis-app/build.rs
@@ -1,10 +1,28 @@
 fn main() {
-    // link to Vosk lib
-    // println!("cargo:rustc-link-lib=libvosk.dll");
-
     let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     let lib_path = std::path::Path::new(&manifest_dir)
-        .join("..\\..\\lib\\windows\\amd64");
-    
+        .join("..")
+        .join("..")
+        .join("lib")
+        .join("windows")
+        .join("amd64");
+
     println!("cargo:rustc-link-search=native={}", lib_path.display());
+
+    let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let profile = std::env::var("PROFILE").unwrap();
+    let target_dir = out_dir
+        .ancestors()
+        .find(|path| path.file_name().is_some_and(|name| name == std::ffi::OsStr::new(&profile)))
+        .expect("Cargo target profile directory not found");
+
+    for entry in std::fs::read_dir(&lib_path).unwrap() {
+        let entry = entry.unwrap();
+        let source = entry.path();
+        if source.extension().is_some_and(|extension| extension == "dll") {
+            let destination = target_dir.join(entry.file_name());
+            std::fs::copy(&source, destination).unwrap();
+            println!("cargo:rerun-if-changed={}", source.display());
+        }
+    }
 }

--- a/crates/jarvis-cli/src/main.rs
+++ b/crates/jarvis-cli/src/main.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use jarvis_core::{COMMANDS_LIST, DB, JCommandsList, commands, config, db, intent};
+use jarvis_core::{COMMANDS_LIST, DB, JCommandsList, commands, config, db, intent, models};
 
 fn print_help() {
     println!("
@@ -103,6 +103,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // init dirs
     config::init_dirs()?;
+
+    // init model registry before selecting an intent backend
+    models::init()?;
     
     // init settings
     let settings = db::init();

--- a/crates/jarvis-core/Cargo.toml
+++ b/crates/jarvis-core/Cargo.toml
@@ -59,6 +59,6 @@ jarvis_app = [
     "lua",
     "ort", "ndarray", "tokenizers", "regex",]
 
-intent = ["intent-classifier", "tokio"]
+intent = ["intent-classifier", "tokio", "fastembed"]
 lua = ["mlua", "reqwest", "winrt-notification"]
 lua_only = ["lua", "tokio"]

--- a/crates/jarvis-core/src/models.rs
+++ b/crates/jarvis-core/src/models.rs
@@ -7,7 +7,7 @@ pub mod vosk_models;
 pub mod gliner_models;
 
 // re-export loaders
-#[cfg(feature = "jarvis_app")]
+#[cfg(feature = "intent")]
 pub use loaders::embedding;
 
 #[cfg(feature = "jarvis_app")]
@@ -16,7 +16,7 @@ pub use loaders::gliner;
 #[cfg(feature = "jarvis_app")]
 pub use loaders::ort_model;
 
-#[cfg(feature = "jarvis_app")]
+#[cfg(feature = "intent")]
 pub use loaders::intent_classifier;
 
 #[cfg(feature = "vosk")]

--- a/crates/jarvis-core/src/models/loaders/mod.rs
+++ b/crates/jarvis-core/src/models/loaders/mod.rs
@@ -1,10 +1,10 @@
-#[cfg(feature = "jarvis_app")]
+#[cfg(feature = "intent")]
 pub mod embedding;
 #[cfg(feature = "jarvis_app")]
 pub mod gliner;
 #[cfg(feature = "jarvis_app")]
 pub mod ort_model;
-#[cfg(feature = "jarvis_app")]
+#[cfg(feature = "intent")]
 pub mod intent_classifier;
 #[cfg(feature = "vosk")]
 pub mod vosk;


### PR DESCRIPTION
Исправлено

Исправлена конфигурация feature-флагов для CLI: intent теперь включает fastembed и открывает загрузчики embedding и intent_classifier.
Устранены ошибки импорта crate::models::intent_classifier и models::embedding при сборке jarvis-cli.
Добавлена инициализация реестра моделей (models::init()) при запуске CLI, устраняющая panic перед запуском intent-классификатора.
Внешние зависимости

Для сборки ONNX Runtime на Windows потребовались Windows SDK с DXCORE.lib и MSVC v143 из Visual Studio 2022 Build Tools.